### PR TITLE
Update item types

### DIFF
--- a/src/wrappers/getBggCollection.ts
+++ b/src/wrappers/getBggCollection.ts
@@ -1,5 +1,5 @@
 import { bggXmlApiClient } from '../client'
-import type { ClientOptions, OfValue, OneOrNothing } from '../types'
+import type { ClientOptions, OfValue, OneOrNothing, SingleOrMany } from '../types'
 
 type BggCollectionSubtype =
   | 'boardgame'
@@ -44,89 +44,91 @@ export interface BggCollectionParams {
   modifiedsince?: string // YY-MM-DD or YY-MM-DD%20HH:MM:SS
 }
 
-export interface BggCollectionResponse {
-  item: {
-    name: {
-      text: string
-      sortindex: number
+interface BggCollectionItem {
+  name: {
+    text: string
+    sortindex: number
+  }
+  originalname: string
+  yearpublished: number
+  image: string
+  thumbnail: string
+  stats: {
+    rating: {
+      usersrated: OfValue<number>
+      average: OfValue<number>
+      bayesaverage: OfValue<number>
+      stddev: OfValue<number>
+      median: OfValue<number>
+      ranks: {
+        rank: {
+          type: 'subtype' | 'family' | (string & {})
+          id: number
+          name: string
+          friendlyname: string
+          value: number
+          bayesaverage: number
+        }[]
+      }
+      value: string
     }
-    originalname: string
-    yearpublished: number
-    image: string
-    thumbnail: string
-    stats: {
-      rating: {
-        usersrated: OfValue<number>
-        average: OfValue<number>
-        bayesaverage: OfValue<number>
-        stddev: OfValue<number>
-        median: OfValue<number>
-        ranks: {
-          rank: {
-            type: 'subtype' | 'family' | (string & {})
-            id: number
-            name: string
-            friendlyname: string
-            value: number
-            bayesaverage: number
-          }[]
-        }
+    minplayers: 2
+    maxplayers: 2
+    minplaytime: 150
+    maxplaytime: 150
+    playingtime: 150
+    numowned: 4434
+  }
+  status: {
+    own: ZeroOrOne
+    prevowned: ZeroOrOne
+    fortrade: ZeroOrOne
+    want: ZeroOrOne
+    wanttoplay: ZeroOrOne
+    wanttobuy: ZeroOrOne
+    wishlist: ZeroOrOne
+    wishlistpriority?: 1 | 2 | 3 | 4 | 5
+    preordered: ZeroOrOne
+    lastmodified: string
+  }
+  numplays: number
+  version?: {
+    item: {
+      thumbnail: string
+      image: string
+      link: {
+        type:
+        | 'boardgameversion'
+        | 'boardgamepublisher'
+        | 'language'
+        | (string & {})
+        id: number
+        value: string
+        inbound?: boolean
+      }[]
+      name: {
+        type: 'primary' | (string & {})
+        sortindex: number
         value: string
       }
-      minplayers: 2
-      maxplayers: 2
-      minplaytime: 150
-      maxplaytime: 150
-      playingtime: 150
-      numowned: 4434
+      yearpublished: OfValue<number>
+      productcode: OfValue<string>
+      width: OfValue<number>
+      length: OfValue<number>
+      depth: OfValue<number>
+      weight: OfValue<number>
+      type: 'boardgameversion' | (string & {})
+      id: number
     }
-    status: {
-      own: ZeroOrOne
-      prevowned: ZeroOrOne
-      fortrade: ZeroOrOne
-      want: ZeroOrOne
-      wanttoplay: ZeroOrOne
-      wanttobuy: ZeroOrOne
-      wishlist: ZeroOrOne
-      wishlistpriority?: 1 | 2 | 3 | 4 | 5
-      preordered: ZeroOrOne
-      lastmodified: string
-    }
-    numplays: number
-    version?: {
-      item: {
-        thumbnail: string
-        image: string
-        link: {
-          type:
-          | 'boardgameversion'
-          | 'boardgamepublisher'
-          | 'language'
-          | (string & {})
-          id: number
-          value: string
-          inbound?: boolean
-        }[]
-        name: {
-          type: 'primary' | (string & {})
-          sortindex: number
-          value: string
-        }
-        yearpublished: OfValue<number>
-        productcode: OfValue<string>
-        width: OfValue<number>
-        length: OfValue<number>
-        depth: OfValue<number>
-        weight: OfValue<number>
-        type: 'boardgameversion' | (string & {})
-        id: number
-      }
-    }
-    objecttype: 'thing' | (string & {})
-    objectid: number
-    subtype: string
-    collid: number
-  }[]
+  }
+  objecttype: 'thing' | (string & {})
+  objectid: number
+  subtype: string
+  collid: number
+}
+
+export interface BggCollectionResponse {
+  item: SingleOrMany<BggCollectionItem>
   totalitems: number
   termsofuse: string
   pubdate: string

--- a/src/wrappers/getBggGeeklist.ts
+++ b/src/wrappers/getBggGeeklist.ts
@@ -1,5 +1,5 @@
 import bggXmlApiClient from '../client'
-import type { ClientOptions, OneOrNothing } from '../types'
+import type { ClientOptions, OneOrNothing, SingleOrMany } from '../types'
 
 export interface GeeklistParams {
   id: number
@@ -16,6 +16,22 @@ interface GeeklistItemComment {
   [prop: string]: unknown
 }
 
+interface GeeklistItem {
+  body: string
+  comment: GeeklistItemComment | GeeklistItemComment[]
+  id: number
+  objecttype: 'thing' | (string & {})
+  subtype: 'boardgame' | 'boardgameaccessory' | (string & {})
+  objectid: number
+  objectname: string
+  username: string
+  postdate: string
+  editdate: string
+  thumbs: number
+  imageid: number
+  [prop: string]: unknown
+}
+
 export interface GeeklistResponse {
   postdate: string
   postdate_timestamp: number
@@ -26,21 +42,7 @@ export interface GeeklistResponse {
   username: string
   title: string
   description: string
-  item: {
-    body: string
-    comment: GeeklistItemComment | GeeklistItemComment[]
-    id: number
-    objecttype: 'thing' | (string & {})
-    subtype: 'boardgame' | 'boardgameaccessory' | (string & {})
-    objectid: number
-    objectname: string
-    username: string
-    postdate: string
-    editdate: string
-    thumbs: number
-    imageid: number
-    [prop: string]: unknown
-  }[]
+  item: SingleOrMany<GeeklistItem>
   id: number
   termsofuse: string
   [prop: string]: unknown

--- a/src/wrappers/getBggSearch.ts
+++ b/src/wrappers/getBggSearch.ts
@@ -1,5 +1,5 @@
 import { bggXmlApiClient } from '../client'
-import type { ClientOptions, OfValue, OneOrNothing } from '../types'
+import type { ClientOptions, OfValue, OneOrNothing, SingleOrMany } from '../types'
 
 export type SearchType = 'rpgitem' | 'videogame' | 'boardgame' | 'boardgameaccessory' | 'boardgameexpansion'
 
@@ -9,17 +9,19 @@ export interface BggSearchParams {
   exact?: OneOrNothing
 }
 
+interface SearchResponseItem {
+  name: {
+    type: 'primary' | (string & {})
+    value: string
+  }
+  yearpublished?: OfValue<number>
+  type: 'boardgame' | 'boardgameexpansion' | 'rpgitem' | 'videogame' | (string & {})
+  id: number
+  [prop: string]: unknown
+}
+
 export interface BggSearchResponse {
-  item: {
-    name: {
-      type: 'primary' | (string & {})
-      value: string
-    }
-    yearpublished?: OfValue<number>
-    type: 'boardgame' | 'boardgameexpansion' | 'rpgitem' | 'videogame' | (string & {})
-    id: number
-    [prop: string]: unknown
-  }[]
+  item: SingleOrMany<SearchResponseItem>
   total: number
   termsofuse: string
   [prop: string]: unknown


### PR DESCRIPTION
This PR updates a few response types to use `SingleOrMany` for `item`, since they may return a single object or an array of objects, depending on the query.

I started with `BggSearchResponse`, but I also looked for other instances of responses with and `item` property that was an array, and discovered that `GeeklistResponse` and `BggCollectionResponse` had the same issue, so I updated those as well.

Closes #24 